### PR TITLE
Fix for out_of_range exception

### DIFF
--- a/include/signal_matcher/signal_matcher.h
+++ b/include/signal_matcher/signal_matcher.h
@@ -23,7 +23,7 @@ namespace uvdar {
           for (int i=0; i<sequence_size_; i++){ //slide along the duplicated sequence
             int match_errors = 0;
             for (int j=0; j<(int)(i_signal.size()); j++){ //iterate over signal
-              if (sequences_.at(s).at(i+j) != i_signal.at(j)){
+              if (sequences_.at(s).at((i+j) % sequence_size_) != i_signal.at(j)){
                 match_errors++;
               }
               if (match_errors > MATCH_ERROR_THRESHOLD) {//TODO make settable


### PR DESCRIPTION
Based on https://www.cplusplus.com/reference/vector/vector/at/, when the argument (position) is greater than, or equal to, the vector size, an exception of type out_of_range is thrown.